### PR TITLE
Experimental macros

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1,6 +1,8 @@
 #lang racketscript/base
 
-(require (for-syntax racket/base syntax/parse)
+(require (for-syntax racket/base
+                     racket/syntax
+                     syntax/parse)
          racketscript/interop
          racket/stxparam
          racket/list)
@@ -15,11 +17,12 @@
          define-component
          create-context
          with-context
+         use-context
          in-context
          $ctx
          use-state
+         define-state
          use-effect
-         use-context
          use-reducer
          use-callback
          use-memo
@@ -31,6 +34,16 @@
 ;; Basic hooks
 (define (use-state default-state)
     (apply values (js-array->list (#js.React.useState default-state))))
+
+;; (define-state name val) is shorthand for creating a React State Hook
+;; It defines two identifiers:
+;; - name: the current value of the state
+;; - set-name!: a setter used to change the state's value
+(define-syntax define-state
+  (syntax-parser
+    [(_ name default-val)
+     #:with set-name! (format-id #'name "set-~a!" #'name)
+     #'(define-values (name set-name!) (use-state default-val))]))
 
 (define use-effect #js.React.useEffect)
 

--- a/main.rkt
+++ b/main.rkt
@@ -1,6 +1,7 @@
 #lang racketscript/base
 
-(require racketscript/interop
+(require (for-syntax racket/base syntax/parse)
+         racketscript/interop
          racket/list)
 
 (define React ($/require/* "react"))
@@ -8,6 +9,7 @@
 
 (provide render
          <el
+         <>
          create-context
          use-state
          use-effect
@@ -61,6 +63,13 @@
 
 ;; A small alias for readability
 (define <el create-element)
+
+;; a macro version of <el that tries to hide some boilerplate
+(define-syntax <>
+  (syntax-parser
+    [(_ name #:props ([x:id v] ...) . body)
+     #'(<el name #:props ($/obj [x v] ...) . body)]
+    [(_ name . body) #'(<el name . body)]))
 
 (define (render react-element node-id)
     (#js.ReactDOM.render react-element (#js*.document.getElementById node-id)))

--- a/main.rkt
+++ b/main.rkt
@@ -14,6 +14,9 @@
          $props
          define-component
          create-context
+         with-context
+         in-context
+         $ctx
          use-state
          use-effect
          use-context
@@ -88,6 +91,27 @@
              ([$props (syntax-parser
                         [:id #'props]
                         [(_ . args) #'($ props . args)])])
+           . body))]))
+
+(define-syntax with-context
+  (syntax-parser
+    [(_ ctx-name (~datum =) default-value . body)
+     #'(<> ($ ctx-name 'Provider) #:props ([value default-value]) . body)]))
+
+(define-syntax-parameter $ctx
+  (syntax-parser
+    [_ #'(error '$ctx "Warning: $ctx keyword cannot be used outside Rackt in-context body")]))
+
+(define-syntax in-context
+  (syntax-parser
+    [(_ ctx-name . body)
+     #'(let ([ctx (use-context ctx-name)])
+         (syntax-parameterize
+             ;; $ctx may be used as an id,
+             ;; or in head position where an implicit $ is inserted
+             ([$ctx (syntax-parser
+                      [:id #'ctx]
+                      [(_ . args) #'($ ctx . args)])])
            . body))]))
 
 (define (render react-element node-id)


### PR DESCRIPTION
Had some fun adding a bunch of experimental macros to Rackt that tried to simplify or hide a lot of js/react boilerplate when working with hooks and reducers (The original API is unchanged.) Would be interested to know if anyone would find these useful